### PR TITLE
Fix error when there are no 'user-agent' header

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -291,7 +291,7 @@ var UserAgent = function() {
 
     this.express = function() {
         return function(req, res, next) {
-            var source = req.headers['user-agent'],
+            var source = req.headers['user-agent'] || '',
             ua = new UserAgent();
             ua.Agent.source = source.replace(/^\s*/, '').replace(/\s*$/, '');
             ua.Agent.OS = ua.getOS(ua.Agent.source);


### PR DESCRIPTION
express-useragent fails when there is no 'user-agent' header in the request. This fixes it.
