### PR TITLE
Detect Android Tablet

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -103,6 +103,7 @@ var UserAgent = function() {
         isSamsung : false,
         isRaspberry : false,
         isBot : false,
+        isAndroidTablet : false,
         Browser : 'unknown',
         Version : 'unknown',
         OS : 'unknown',
@@ -373,7 +374,14 @@ var UserAgent = function() {
              ua.Agent.isBot = true;
         }
     };
-    
+
+    this.testAndriodTablet = function testAndriodTablet() {
+        var ua = this;
+        if(ua.Agent.isAndroid && !/mobile/i.test(ua.Agent.source)) {
+            ua.Agent.isAndroidTablet = true;
+        }
+    };
+
     this.parse = function parse(source) {
         var ua = new UserAgent();
         ua.Agent.source = source.replace(/^\s*/, '').replace(/\s*$/, '');
@@ -383,6 +391,7 @@ var UserAgent = function() {
         ua.Agent.Version = ua.getBrowserVersion(ua.Agent.source);
         ua.testBot();
         ua.testMobile();
+        ua.testAndriodTablet();
         return ua.Agent;
     };
 
@@ -399,6 +408,7 @@ var UserAgent = function() {
             ua.testNginxGeoIP(req.headers);
             ua.testBot();
             ua.testMobile();
+            ua.testAndriodTablet();
             req.useragent = ua.Agent;
             res.locals({"useragent" : ua.Agent});
             next();

--- a/tests/android_phone.js
+++ b/tests/android_phone.js
@@ -1,0 +1,54 @@
+/**
+ * @author Sivaprakasam Boopathy <sivaprakasam.boopathy@gmail.com>
+ *
+ * http://android-developers.blogspot.com/2010/12/android-browser-user-agent-issues.html
+ * Based on the above post to detect the Android tablet.
+**/
+
+var ua = require('../lib/express-useragent');
+
+exports['Andriod Phone'] = function(test) {
+
+    var source = '';
+    source += 'Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; ';
+    source += 'SAMSUNG-SGH-I777 Build/JZO54K) ';
+    source += 'AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30';
+
+    var userAgent = ua.parse(source);
+
+    test.ok(userAgent.isMobile, 'Mobile');
+    test.ok(!userAgent.isiPad, 'iPad');
+    test.ok(!userAgent.isiPod, 'iPod');
+    test.ok(!userAgent.isiPhone, 'iPhone');
+    test.ok(userAgent.isAndroid, 'Android');
+    test.ok(!userAgent.isBlackberry, 'Blackberry');
+    test.ok(!userAgent.isOpera, 'Opera');
+    test.ok(!userAgent.isIE, 'IE');
+    test.ok(userAgent.isSafari, 'Safari');
+    test.ok(!userAgent.isFirefox, 'Firefox');
+    test.ok(!userAgent.isWebkit, 'Webkit');
+    test.ok(!userAgent.isChrome, 'Chrome');
+    test.ok(!userAgent.isKonqueror, 'Konqueror');
+    test.ok(!userAgent.isOmniWeb, 'OmniWeb');
+    test.ok(!userAgent.isSeaMonkey, 'SeaMonkey');
+    test.ok(!userAgent.isFlock, 'Flock');
+    test.ok(!userAgent.isAmaya, 'Amaya');
+    test.ok(!userAgent.isEpiphany, 'Epiphany');
+    test.ok(!userAgent.isDesktop, 'Desktop');
+    test.ok(!userAgent.isWindows, 'Windows');
+    test.ok(userAgent.isLinux, 'Linux');
+    test.ok(!userAgent.isMac, 'Mac');
+    test.ok(!userAgent.isBada, 'Bada');
+    test.ok(!userAgent.isSamsung, 'Samsung');
+    test.ok(!userAgent.isRaspberry, 'Raspberry');
+    test.ok(!userAgent.isBot, 'Bot');
+    test.ok(!userAgent.isAndroidTablet, 'AndroidTablet');
+
+    test.equal(userAgent.Browser, 'Safari');
+    test.equal(userAgent.OS, 'Linux');
+    test.equal(userAgent.Platform, 'Android');
+    test.equal(0, Object.keys(userAgent.GeoIP).length );
+    test.equal(userAgent.Version, '4.0');
+
+    test.done();
+};

--- a/tests/android_tablet.js
+++ b/tests/android_tablet.js
@@ -1,0 +1,54 @@
+/**
+ * @author Sivaprakasam Boopathy <sivaprakasam.boopathy@gmail.com>
+ *
+ * http://android-developers.blogspot.com/2010/12/android-browser-user-agent-issues.html
+ * Based on the above post to detect the Android tablet.
+**/
+
+var ua = require('../lib/express-useragent');
+
+exports['Andriod Tablet'] = function(test) {
+
+    var source = '';
+    source += 'Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ';
+    source += 'SAMSUNG-SGH-I957 Build/IMM76D) ';
+    source += 'AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30';
+
+    var userAgent = ua.parse(source);
+
+    test.ok(userAgent.isMobile, 'Mobile');
+    test.ok(!userAgent.isiPad, 'iPad');
+    test.ok(!userAgent.isiPod, 'iPod');
+    test.ok(!userAgent.isiPhone, 'iPhone');
+    test.ok(userAgent.isAndroid, 'Android');
+    test.ok(!userAgent.isBlackberry, 'Blackberry');
+    test.ok(!userAgent.isOpera, 'Opera');
+    test.ok(!userAgent.isIE, 'IE');
+    test.ok(userAgent.isSafari, 'Safari');
+    test.ok(!userAgent.isFirefox, 'Firefox');
+    test.ok(!userAgent.isWebkit, 'Webkit');
+    test.ok(!userAgent.isChrome, 'Chrome');
+    test.ok(!userAgent.isKonqueror, 'Konqueror');
+    test.ok(!userAgent.isOmniWeb, 'OmniWeb');
+    test.ok(!userAgent.isSeaMonkey, 'SeaMonkey');
+    test.ok(!userAgent.isFlock, 'Flock');
+    test.ok(!userAgent.isAmaya, 'Amaya');
+    test.ok(!userAgent.isEpiphany, 'Epiphany');
+    test.ok(!userAgent.isDesktop, 'Desktop');
+    test.ok(!userAgent.isWindows, 'Windows');
+    test.ok(userAgent.isLinux, 'Linux');
+    test.ok(!userAgent.isMac, 'Mac');
+    test.ok(!userAgent.isBada, 'Bada');
+    test.ok(!userAgent.isSamsung, 'Samsung');
+    test.ok(!userAgent.isRaspberry, 'Raspberry');
+    test.ok(!userAgent.isBot, 'Bot');
+    test.ok(userAgent.isAndroidTablet, 'AndroidTablet');
+
+    test.equal(userAgent.Browser, 'Safari');
+    test.equal(userAgent.OS, 'Linux');
+    test.equal(userAgent.Platform, 'Android');
+    test.equal(0, Object.keys(userAgent.GeoIP).length );
+    test.equal(userAgent.Version, '4.0');
+
+    test.done();
+};


### PR DESCRIPTION
Added the ability to detect whether the device is Android tablet. By looking the isAndroidTablet attribute in user agent hash we can identify whether the android device tablet or not. 
