### PR TITLE
add testing Google AdsBot rule

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -500,7 +500,7 @@ var UserAgent = function() {
 
     this.testBot = function testBot() {
         var ua = this;
-        if (/googlebot|gurujibot|twitterbot|yandexbot|slurp|msnbot|bingbot|facebookexternalhit/i.test(ua.Agent.source)) {
+        if (/googlebot|adsbot-google|gurujibot|twitterbot|yandexbot|slurp|msnbot|bingbot|facebookexternalhit/i.test(ua.Agent.source)) {
             ua.Agent.isBot = true;
         }
     };


### PR DESCRIPTION
I updated bot testing rule to detect the Google Ads bot, which annoying the servers by visiting password reset URL of users sent to Gmail.

Original UA: `AdsBot-Google (+http://www.google.com/adsbot.html)`