### PR TITLE
Chrome on Windows 10 reports Windows NT 10.0 user Agent

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -48,6 +48,7 @@ var UserAgent = function() {
         WinJs: /msapphost/i
     };
     this._OS = {
+        Windows10: /windows nt 10\.0/i,
         Windows81: /windows nt 6\.3/i,
         Windows8: /windows nt 6\.2/i,
         Windows7: /windows nt 6\.1/i,
@@ -275,6 +276,9 @@ var UserAgent = function() {
             case this._OS.Windows81.test(string):
                 this.Agent.isWindows = true;
                 return 'Windows 8.1';
+            case this._OS.Windows10.test(string):
+                this.Agent.isWindows = true;
+                return 'Windows 10.0';
             case this._OS.Windows2003.test(string):
                 this.Agent.isWindows = true;
                 return 'Windows 2003';


### PR DESCRIPTION
 'user-agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.111 Safari/537.36',