### PR TITLE
Allow for parsing of unauthoritative useragent strings

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -115,6 +115,7 @@
         };
 
         this.DefaultAgent = {
+            isAuthoritative: true,
             isMobile: false,
             isTablet: false,
             isiPad: false,
@@ -213,6 +214,11 @@
                     this.Agent.isFirefox = true;
                     return 'Firefox';
                 default:
+                    // If the UA does not start with Mozilla guess the user agent.
+                    if (string.indexOf('Mozilla') !== 0 && /^([\d\w\-\.]+)\/[\d\w\.\-]+/i.test(string)) {
+                        this.Agent.isAuthoritative = false;
+                        return RegExp.$1;
+                    }
                     return 'unknown';
             }
         };
@@ -296,9 +302,11 @@
                     }
                     break;
                 default:
-                    regex = /#{name}[\/ ]([\d\w\.\-]+)/i;
-                    if (regex.test(string)) {
-                        return RegExp.$1;
+                    if (this.Agent.browser !== 'unknown') {
+                        regex = new RegExp(this.Agent.browser + '[\\/ ]([\\d\\w\\.\\-]+)', 'i');
+                        if (regex.test(string)) {
+                            return RegExp.$1;
+                        }
                     }
             }
         };
@@ -601,6 +609,9 @@
             var isBot = IS_BOT_REGEXP.exec(ua.Agent.source.toLowerCase());
             if (isBot) {
                 ua.Agent.isBot = isBot[1];
+            } else if (!ua.Agent.isAuthoritative) {
+                // Test unauthoritative parse for `bot` in UA to flag for bot
+                ua.Agent.isBot = /bot/i.test(ua.Agent.source);
             }
         };
 

--- a/test/bots_test.js
+++ b/test/bots_test.js
@@ -4,12 +4,53 @@
 
 var ua = require('../');
 
+
+exports['Arbitrary bot UA'] = function (test) {
+
+    var source = 'sockbot/3.1.0-RC1 (Linux x86_64) (nodejs 5.10.1) (owner:fred user:george)';
+
+    var userAgent = ua.parse(source);
+
+    test.ok(!userAgent.isAuthoritative, 'Authoritative');
+    test.ok(!userAgent.isMobile, 'Mobile');
+    test.ok(!userAgent.isiPad, 'iPad');
+    test.ok(!userAgent.isiPod, 'iPod');
+    test.ok(!userAgent.isiPhone, 'iPhone');
+    test.ok(!userAgent.isAndroid, 'Android');
+    test.ok(!userAgent.isBlackberry, 'Blackberry');
+    test.ok(!userAgent.isOpera, 'Opera');
+    test.ok(!userAgent.isIE, 'IE');
+    test.ok(!userAgent.isSafari, 'Safari');
+    test.ok(!userAgent.isFirefox, 'Firefox');
+    test.ok(!userAgent.isWebkit, 'Webkit');
+    test.ok(!userAgent.isChrome, 'Chrome');
+    test.ok(!userAgent.isKonqueror, 'Konqueror');
+    test.ok(!userAgent.isOmniWeb, 'OmniWeb');
+    test.ok(!userAgent.isSeaMonkey, 'SeaMonkey');
+    test.ok(!userAgent.isFlock, 'Flock');
+    test.ok(!userAgent.isAmaya, 'Amaya');
+    test.ok(!userAgent.isEpiphany, 'Epiphany');
+    test.ok(userAgent.isDesktop, 'Desktop');
+    test.ok(!userAgent.isWindows, 'Windows');
+    test.ok(userAgent.isLinux, 'Linux');
+    test.ok(!userAgent.isMac, 'Mac');
+    test.ok(!userAgent.isBada, 'Bada');
+    test.ok(!userAgent.isSamsung, 'Samsung');
+    test.ok(!userAgent.isRaspberry, 'Raspberry');
+    test.ok(userAgent.isBot, 'Bot');
+    test.ok(!userAgent.isAndroidTablet, 'AndroidTablet');
+    test.equal(userAgent.browser, 'sockbot');
+    test.equal(userAgent.version, '3.1.0-RC1');
+    test.done();
+};
+
 exports['Baiduspider Bot'] = function (test) {
 
     var source = 'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)';
 
     var userAgent = ua.parse(source);
 
+    test.ok(userAgent.isAuthoritative, 'Authoritative');
     test.ok(!userAgent.isMobile, 'Mobile');
     test.ok(!userAgent.isiPad, 'iPad');
     test.ok(!userAgent.isiPod, 'iPod');
@@ -47,6 +88,7 @@ exports['Apple Bot'] = function (test) {
 
     var userAgent = ua.parse(source);
 
+    test.ok(userAgent.isAuthoritative, 'Authoritative');
     test.ok(!userAgent.isMobile, 'Mobile');
     test.ok(!userAgent.isiPad, 'iPad');
     test.ok(!userAgent.isiPod, 'iPod');
@@ -84,6 +126,7 @@ exports['Pingdom Bot'] = function(test) {
 
     var userAgent = ua.parse(source);
 
+    test.ok(userAgent.isAuthoritative, 'Authoritative');
     test.ok(!userAgent.isMobile, 'Mobile');
     test.ok(!userAgent.isiPad, 'iPad');
     test.ok(!userAgent.isiPod, 'iPod');

--- a/test/browsers.js
+++ b/test/browsers.js
@@ -11,6 +11,7 @@ exports['iPad 2'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(a.isMobile, 'Mobile');
     test.ok(a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -41,6 +42,7 @@ exports['Linux Iceweasel'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -70,6 +72,7 @@ exports['Linux 64 Chrome'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -99,6 +102,7 @@ exports['Linux Firefox 11'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -130,6 +134,7 @@ exports['Linux Chrome 17'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -160,6 +165,7 @@ exports['Linux Chromium 39'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -191,6 +197,7 @@ exports['Linux Ephiphany 2.30'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -221,6 +228,7 @@ exports['Windows 8 Chrome 28'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -251,6 +259,7 @@ exports['Windows 8.1 WinJs'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -282,6 +291,7 @@ exports['Windows 7 Firefox 23'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -312,6 +322,7 @@ exports['Windows XP IE 5.5'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -341,6 +352,7 @@ exports['Windows XP IE 6.0'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -370,6 +382,7 @@ exports['Windows XP IE 7.0'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -399,6 +412,7 @@ exports['Windows XP Opera'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -429,6 +443,7 @@ exports['Windows XP Safari'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -459,6 +474,7 @@ exports['Windows XP Chrome'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -489,6 +505,7 @@ exports['Windows Phone 8'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -519,6 +536,7 @@ exports['OS X OmniWeb 622'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -550,6 +568,7 @@ exports['OS X Safari 530'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -579,6 +598,7 @@ exports['OS X Chromium'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(a.isMobile, 'Mobile');
     test.ok(a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -613,6 +633,7 @@ exports['Android Samsung'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -646,6 +667,7 @@ exports['Android Xoom'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -713,6 +735,7 @@ exports['Bada OS browser'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -744,6 +767,7 @@ exports['America Online Browser'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -802,6 +826,7 @@ exports['Windows 7 IE 11.0'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -830,6 +855,7 @@ exports['Windows 8.1 IE 11 Touch'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -859,6 +885,7 @@ exports['Windows XP IE 8.0'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -888,6 +915,7 @@ exports['Windows XP IE 8.0 - Compatibility mode'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -918,6 +946,7 @@ exports['Windows XP IE 10.0'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -948,6 +977,7 @@ exports['Windows XP IE 10.0 - Compatibility mode'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -978,6 +1008,7 @@ exports['Windows XP IE 7.0 - Compatibility mode (invalid mode)'] = function (tes
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -1009,6 +1040,7 @@ exports['Windows XP IE 9.0 - Compatibility mode'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -1040,6 +1072,7 @@ exports['Mac OSX Opera 30'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -1071,6 +1104,7 @@ exports['Microsoft Edge 12'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(!a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');
@@ -1103,6 +1137,7 @@ exports['Microsoft Edge Mobile'] = function (test) {
 
     var a = ua.parse(s);
 
+    test.ok(a.isAuthoritative, 'Authoritative');
     test.ok(a.isMobile, 'Mobile');
     test.ok(!a.isiPad, 'iPad');
     test.ok(!a.isiPod, 'iPod');


### PR DESCRIPTION
This change allows express-useragent to "guess" browser name and version from arbitrary useragent strings that are not marked as `Mozilla/5.0` compatible.

It also adds a flag to the parsed useragent that indicates that such a parse is not authoritative so that consuming webapps can alter their logic as needed in the case of an authoritative vs. unauthoritative response.

Also added is a final check for bots on unauthoritaive useragents by looking for the characters `bot` in the useragents that are marked as unauthoritative.