### PR TITLE
Adding embed.ly bot

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -22,7 +22,8 @@
         'telegrambot',
         'applebot',
         'pingdom',
-        'tumblr '
+        'tumblr ',
+        'Embedly'
     ];
     var IS_BOT_REGEXP = new RegExp('^.*(' + BOTS.join('|') + ').*$');
 


### PR DESCRIPTION
Embed.ly crowler use `Mozilla/5.0 (compatible; Embedly/0.2; +http://support.embed.ly/)` UA string, so it seems like this check should be good enough.
TBD: shall `IS_BOT_REGEXP` be case sensitive?