### PR TITLE
Remove nodeunit from production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,7 @@
   "engines": {
     "node": ">=0.8"
   },
-  "dependencies": {
-    "nodeunit": "0.10.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "nodeunit": "*",
     "jshint": "*",


### PR DESCRIPTION
5713f103086c4c064f63e216e7748638f571c52c added nodeunit as production dependency, even though it is already listed as devDependency. This leads to lots of unnecessary packages beeing installed in production.

Fixes #65 

---

Did a quick test in our project, seems to work fine.
