### PR TITLE
Add support for MSIE 11 on Windows Phone 8.1

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -103,7 +103,8 @@
             Windows2003: /windows nt 5\.2/i,
             WindowsXP: /windows nt 5\.1/i,
             Windows2000: /windows nt 5\.0/i,
-            WindowsPhone8: /windows phone 8\./,
+            WindowsPhone81: /windows phone 8\.1/i,
+            WindowsPhone80: /windows phone 8\.0/i,
             OSXCheetah: /os x 10[._]0/i,
             OSXPuma: /os x 10[._]1(\D|$)/i,
             OSXJaguar: /os x 10[._]2/i,
@@ -233,15 +234,15 @@
                 case this._Browsers.Chrome.test(string):
                     this.Agent.isChrome = true;
                     return 'Chrome';
-                case this._Browsers.Safari.test(string):
-                    this.Agent.isSafari = true;
-                    return 'Safari';
                 case this._Browsers.WinJs.test(string):
                     this.Agent.isWinJs = true;
                     return 'WinJs';
                 case this._Browsers.IE.test(string):
                     this.Agent.isIE = true;
                     return 'IE';
+                case this._Browsers.Safari.test(string):
+                    this.Agent.isSafari = true;
+                    return 'Safari';
                 case this._Browsers.PS3.test(string):
                     return 'ps3';
                 case this._Browsers.PSP.test(string):
@@ -386,8 +387,12 @@
                 case this._OS.Windows2000.test(string):
                     this.Agent.isWindows = true;
                     return 'Windows 2000';
-                case this._OS.WindowsPhone8.test(string):
-                    return 'Windows Phone 8';
+                case this._OS.WindowsPhone81.test(string):
+                    this.Agent.isWindowsPhone = true;
+                    return 'Windows Phone 8.1';
+                case this._OS.WindowsPhone80.test(string):
+                    this.Agent.isWindowsPhone = true;
+                    return 'Windows Phone 8.0';
                 case this._OS.Linux64.test(string):
                     this.Agent.isLinux = true;
                     this.Agent.isLinux64 = true;

--- a/test/browsers.js
+++ b/test/browsers.js
@@ -498,7 +498,7 @@ exports['Windows XP Chrome'] = function (test) {
     test.done();
 };
 
-exports['Windows Phone 8'] = function (test) {
+exports['Windows Phone 8.0'] = function (test) {
 
     var s = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; ' +
         'Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)';
@@ -525,6 +525,37 @@ exports['Windows Phone 8'] = function (test) {
     test.ok(!a.isLinux, 'Linux');
     test.ok(!a.isMac, 'Mac');
     test.equal(a.version, '10.0');
+
+    test.done();
+};
+
+exports['Windows Phone 8.1'] = function (test) {
+
+    var s = 'Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; ' +
+        'Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 920) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537';
+
+    var a = ua.parse(s);
+
+    test.ok(a.isAuthoritative, 'Authoritative');
+    test.ok(a.isMobile, 'Mobile');
+    test.ok(!a.isiPad, 'iPad');
+    test.ok(!a.isiPod, 'iPod');
+    test.ok(!a.isiPhone, 'iPhone');
+    test.ok(!a.isAndroid, 'Android');
+    test.ok(!a.isBlackberry, 'Blackberry');
+    test.ok(!a.isOpera, 'Opera');
+    test.ok(a.isIE, 'IE');
+    test.ok(!a.isSafari, 'Safari');
+    test.ok(!a.isFirefox, 'Firefox');
+    test.ok(!a.isWebkit, 'Webkit');
+    test.ok(!a.isChrome, 'Chrome');
+    test.ok(!a.isKonqueror, 'Konqueror');
+    test.ok(!a.isDesktop, 'Desktop');
+    test.ok(!a.isWindows, 'Windows');
+    test.ok(a.isWindowsPhone, 'Windows Phone');
+    test.ok(!a.isLinux, 'Linux');
+    test.ok(!a.isMac, 'Mac');
+    test.equal(a.version, '11.0');
 
     test.done();
 };


### PR DESCRIPTION
Fixes #76 

Also added support to tell between WP8.0 and WP8.1, and added a test using a real Nokia Lumia 920 UA 🙂