### PR TITLE
Fixed isBot and isSmartTV tests to return boolean instead of string

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -360,12 +360,7 @@
                     }
                     break;
                 default:
-                    if (this.Agent.browser !== 'unknown') {
-                        regex = new RegExp(this.Agent.browser + '[\\/ ]([\\d\\w\\.\\-]+)', 'i');
-                        if (regex.test(string)) {
-                            return RegExp.$1;
-                        }
-                    }
+                    return 'unknown';
             }
         };
 
@@ -645,6 +640,7 @@
                     break;
                 default:
             }
+            // Test unauthoritative parse for `mobile` in UA to flag for mobile
             if (/mobile/i.test(ua.Agent.source)) {
                 ua.Agent.isMobile = true;
                 ua.Agent.isDesktop = false;
@@ -660,6 +656,7 @@
                     ua.Agent.isTablet = true;
                     break;
             }
+            // Test unauthoritative parse for `tablet` in UA to flag for tablet
             if (/tablet/i.test(ua.Agent.source)) {
                 ua.Agent.isTablet = true;
             }

--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -678,18 +678,18 @@
             var ua = this;
             var isBot = IS_BOT_REGEXP.exec(ua.Agent.source.toLowerCase());
             if (isBot) {
-                ua.Agent.isBot = isBot[1];
+                ua.Agent.isBot = isBot[1] ? true : false;
             } else if (!ua.Agent.isAuthoritative) {
                 // Test unauthoritative parse for `bot` in UA to flag for bot
                 ua.Agent.isBot = /bot/i.test(ua.Agent.source);
             }
         };
 
-        this.testSmartTV = function testBot() {
+        this.testSmartTV = function testSmartTV() {
             var ua = this;
             var isSmartTV = new RegExp('smart-tv|smarttv|googletv|appletv|hbbtv|pov_tv|netcast.tv','gi').exec(ua.Agent.source.toLowerCase());
             if (isSmartTV) {
-                ua.Agent.isSmartTV = isSmartTV[1];
+                ua.Agent.isSmartTV = isSmartTV[1] ? true : false;
             }
         };
 


### PR DESCRIPTION
Currently user agents such as `facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)` return `isBot: 'facebookexternalhit'` vs `isBot: true`.