### PR TITLE
removed redundant code: isDesktop = false

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -628,7 +628,6 @@
                 case ua.Agent.isAndroid:
                 case ua.Agent.isSamsung:
                     ua.Agent.isMobile = true;
-                    ua.Agent.isDesktop = false;
                     break;
                 default:
             }


### PR DESCRIPTION
`ua.Agent.isDesktop` is false as default. So there is no reason to set it to false after checking `ua.Agent.isAndroid` and `ua.Agent.isSamsung` IMO.