### PR TITLE
Add Facebook browser with iOS and Android tests

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -79,7 +79,8 @@
             Epiphany: /epiphany\/([\d\w\.\-]+)/i,
             WinJs: /msapphost\/([\d\w\.\-]+)/i,
             PhantomJS: /phantomjs\/([\d\w\.\-]+)/i,
-            UC: /UCBrowser\/([\d\w\.]+)/i
+            UC: /UCBrowser\/([\d\w\.]+)/i,
+            Facebook: /FBAV\/([\d\w\.]+)/i
         };
         this._Browsers = {
             Edge: /edge/i,
@@ -99,7 +100,8 @@
             Firefox: /firefox/i,
             WinJs: /msapphost/i,
             PhantomJS: /phantomjs/i,
-            UC: /UCBrowser/i
+            UC: /UCBrowser/i,
+            Facebook: /FBA[NV]/
         };
         this._OS = {
             Windows10: /windows nt 10\.0/i,
@@ -196,6 +198,7 @@
             isCaptive: false,
             isSmartTV: false,
             isUC : false,
+            isFacebook : false,
             silkAccelerated: false,
             browser: 'unknown',
             version: 'unknown',
@@ -239,6 +242,9 @@
                 case this._Browsers.Chromium.test(string):
                     this.Agent.isChrome = true;
                     return 'Chromium';
+                case this._Browsers.Facebook.test(string):
+                    this.Agent.isFacebook = true;
+                    return 'Facebook';
                 case this._Browsers.Chrome.test(string):
                     this.Agent.isChrome = true;
                     return 'Chrome';
@@ -356,6 +362,11 @@
                     break;
                 case 'UCBrowser':
                     if (this._Versions.UC.test(string)) {
+                        return RegExp.$1;
+                    }
+                    break;
+                case 'Facebook':
+                    if (this._Versions.Facebook.test(string)) {
                         return RegExp.$1;
                     }
                     break;

--- a/test/browsers.js
+++ b/test/browsers.js
@@ -553,6 +553,7 @@ exports['Windows Phone 8.1'] = function (test) {
     test.ok(!a.isDesktop, 'Desktop');
     test.ok(!a.isWindows, 'Windows');
     test.ok(a.isWindowsPhone, 'Windows Phone');
+    test.ok(!a.isFacebook, 'Facebook');
     test.ok(!a.isLinux, 'Linux');
     test.ok(!a.isMac, 'Mac');
     test.equal(a.version, '11.0');
@@ -717,6 +718,7 @@ exports['Android Xoom'] = function (test) {
     test.ok(a.isLinux, 'Linux');
     test.ok(!a.isMac, 'Mac');
     test.ok(!a.isWindowsPhone, 'Windows Phone');
+    test.ok(!a.isFacebook, 'Facebook');
     test.equal(a.version, '4.0');
 
     test.done();
@@ -1188,6 +1190,7 @@ exports['Microsoft Edge Mobile'] = function (test) {
     test.ok(!a.isLinux, 'Linux');
     test.ok(!a.isMac, 'Mac');
     test.ok(a.isWindowsPhone, 'Windows Phone');
+    test.ok(!a.isFacebook, 'Facebook');
     test.equal(a.version, '12.0');
     test.ok(!a.isIECompatibilityMode);
 
@@ -1221,7 +1224,78 @@ exports['PhantomJS'] = function (test) {
     test.ok(!a.isMac, 'Mac');
     test.ok(!a.isWindowsPhone, 'Windows Phone');
     test.ok(a.isPhantomJS, 'PhantomJS');
+    test.ok(!a.isFacebook, 'Facebook');
     test.equal(a.version, '1.9.8');
+    test.ok(!a.isIECompatibilityMode);
+
+    test.done();
+};
+
+exports['Facebook on iPhone'] = function (test) {
+
+    var s = '[FBAN/FBIOS;FBAV/137.0.0.44.48;FBBV/68333368;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/10.3.3;' +
+        'FBSS/2;FBCR/AT&T;FBID/phone;FBLC/en_GB;FBOP/5;FBRV/0]';
+
+    var a = ua.parse(s);
+
+    test.ok(a.isAuthoritative, 'Authoritative');
+    test.ok(a.isMobile, 'Mobile');
+    test.ok(!a.isiPad, 'iPad');
+    test.ok(!a.isiPod, 'iPod');
+    test.ok(a.isiPhone, 'iPhone');
+    test.ok(!a.isAndroid, 'Android');
+    test.ok(!a.isBlackberry, 'Blackberry');
+    test.ok(!a.isOpera, 'Opera');
+    test.ok(!a.isIE, 'IE');
+    test.ok(!a.isEdge, 'Edge');
+    test.ok(!a.isSafari, 'Safari');
+    test.ok(!a.isFirefox, 'Firefox');
+    test.ok(!a.isWebkit, 'Webkit');
+    test.ok(!a.isChrome, 'Chrome');
+    test.ok(!a.isKonqueror, 'Konqueror');
+    test.ok(!a.isDesktop, 'Desktop');
+    test.ok(!a.isWindows, 'Windows');
+    test.ok(!a.isLinux, 'Linux');
+    test.ok(!a.isMac, 'Mac');
+    test.ok(!a.isWindowsPhone, 'Windows Phone');
+    test.ok(!a.isPhantomJS, 'PhantomJS');
+    test.ok(a.isFacebook, 'Facebook');
+    test.equal(a.version, '137.0.0.44.48');
+    test.ok(!a.isIECompatibilityMode);
+
+    test.done();
+};
+
+exports['Facebook on Android'] = function (test) {
+
+    var s = 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47Z; wv) AppleWebKit/537.36 (KHTML, like Gecko)' +
+        ' Version/4.0 Chrome/60.0.3112.107 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/132.0.0.20.90;]';
+
+    var a = ua.parse(s);
+
+    test.ok(a.isAuthoritative, 'Authoritative');
+    test.ok(a.isMobile, 'Mobile');
+    test.ok(!a.isiPad, 'iPad');
+    test.ok(!a.isiPod, 'iPod');
+    test.ok(!a.isiPhone, 'iPhone');
+    test.ok(a.isAndroid, 'Android');
+    test.ok(!a.isBlackberry, 'Blackberry');
+    test.ok(!a.isOpera, 'Opera');
+    test.ok(!a.isIE, 'IE');
+    test.ok(!a.isEdge, 'Edge');
+    test.ok(!a.isSafari, 'Safari');
+    test.ok(!a.isFirefox, 'Firefox');
+    test.ok(!a.isWebkit, 'Webkit');
+    test.ok(!a.isChrome, 'Chrome');
+    test.ok(!a.isKonqueror, 'Konqueror');
+    test.ok(!a.isDesktop, 'Desktop');
+    test.ok(!a.isWindows, 'Windows');
+    test.ok(a.isLinux, 'Linux');
+    test.ok(!a.isMac, 'Mac');
+    test.ok(!a.isWindowsPhone, 'Windows Phone');
+    test.ok(!a.isPhantomJS, 'PhantomJS');
+    test.ok(a.isFacebook, 'Facebook');
+    test.equal(a.version, '132.0.0.20.90');
     test.ok(!a.isIECompatibilityMode);
 
     test.done();


### PR DESCRIPTION
I know there are tonnes of in-app browsers out there, but arguably the most important one to many companies is the Facebook one.  Our product managers want to know whether users are browsing our site from the Facebook webview.

Currently `ua.getBrowser` returns "unknown" when passed a user agent string from Facebook on iOS, and returns "Chrome" when passed a ua string from Facebook on Android, which are both inaccurate.

Please consider this pull request to add Facebook to the list of detectable browsers in `express-useragent`.