### PR TITLE
Don't detect Chrome on Android (Oreo) as Opera.  Fixes #89

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -93,7 +93,7 @@
             Chrome: /chrome/i,
             Safari: /safari/i,
             IE: /msie|trident/i,
-            Opera: /opera|OPR/i,
+            Opera: /opera|OPR\//i,
             PS3: /playstation 3/i,
             PSP: /playstation portable/i,
             Firefox: /firefox/i,

--- a/test/browsers.js
+++ b/test/browsers.js
@@ -655,6 +655,40 @@ exports['OS X Chromium'] = function (test) {
 };
 
 // Source:
+// https://www.handsetdetection.com/properties/devices/Google/Pixel
+
+exports['Google Pixel'] = function (test) {
+
+    var s = 'Mozilla/5.0 (Linux; Android 8.0.0; Pixel Build/OPR6.170623.011) AppleWebKit/537.36'
+        + ' (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36';
+
+    var a = ua.parse(s);
+
+    test.ok(a.isAuthoritative, 'Authoritative');
+    test.ok(a.isMobile, 'Mobile');
+    test.ok(!a.isiPad, 'iPad');
+    test.ok(!a.isiPod, 'iPod');
+    test.ok(!a.isiPhone, 'iPhone');
+    test.ok(a.isAndroid, 'Android');
+    test.ok(!a.isBlackberry, 'Blackberry');
+    test.ok(!a.isOpera, 'Opera');
+    test.ok(!a.isIE, 'IE');
+    test.ok(!a.isSafari, 'Safari');
+    test.ok(!a.isFirefox, 'Firefox');
+    test.ok(!a.isWebkit, 'Webkit');
+    test.ok(a.isChrome, 'Chrome');
+    test.ok(!a.isKonqueror, 'Konqueror');
+    test.ok(!a.isDesktop, 'Desktop');
+    test.ok(!a.isWindows, 'Windows');
+    test.ok(a.isLinux, 'Linux');
+    test.ok(!a.isMac, 'Mac');
+    test.ok(!a.isWindowsPhone, 'Windows Phone');
+    test.equal(a.version, '60.0.3112.116');
+
+    test.done();
+};
+
+// Source:
 // http://www.gtrifonov.com/2011/04/15/google-android-user-agent-strings-2/
 
 exports['Android Samsung'] = function (test) {
@@ -1098,7 +1132,7 @@ exports['Windows XP IE 9.0 - Compatibility mode'] = function (test) {
 
 exports['Mac OSX Opera 30'] = function (test) {
 
-    var s = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko)' + 
+    var s = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko)' +
             'Chrome/43.0.2357.125 Safari/537.36 OPR/30.0.1835.88'
 
     var a = ua.parse(s);


### PR DESCRIPTION
Can we roll this fix out ASAP?  This is an issue with the default browser on the latest release of Android... i.e. it's going to affect a lot of people.  Thanks!