### PR TITLE
Support Edge Canary for Mac

### DIFF
--- a/lib/express-useragent.js
+++ b/lib/express-useragent.js
@@ -89,7 +89,7 @@
     var UserAgent = function () {
         this.version = '1.0.12';
         this._Versions = {
-            Edge: /(?:edge|edga|edgios)\/([\d\w\.\-]+)/i,
+            Edge: /(?:edge|edga|edgios|edg)\/([\d\w\.\-]+)/i,
             Firefox: /(?:firefox|fxios)\/([\d\w\.\-]+)/i,
             IE: /msie\s([\d\.]+[\d])|trident\/\d+\.\d+;.*[rv:]+(\d+\.\d)/i,
             Chrome: /(?:chrome|crios)\/([\d\w\.\-]+)/i,


### PR DESCRIPTION
[Edge Canary for Mac is [also] detected as Chrome](https://github.com/biggora/express-useragent/issues/113) https://github.com/biggora/express-useragent/issues/113 

Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3834.0 Safari/537.36 Edg/77.0.207.0
