### PR TITLE
fix: restore ESM default export compatibility for express() and UserAgent (#177)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,4 +60,12 @@ export const express = (): UserAgentMiddleware => {
 };
 export const useragentMiddleware = express;
 
-export default useragent;
+// Export a default instance for easier usage
+// Also attach the express middleware and UserAgent class to the default export
+// to maintain compatibility with documented ESM usage (issue #177)
+const defaultExport = Object.assign(useragent, {
+  express,
+  UserAgent,
+});
+
+export default defaultExport;

--- a/tests/esm-default.test.ts
+++ b/tests/esm-default.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import useragent from '../src/index';
+
+describe('ESM Default Export compatibility (issue #177)', () => {
+  it('default export should have express() method', () => {
+    // @ts-expect-error - testing for existence of express method on default export
+    expect(useragent.express).toBeDefined();
+    // @ts-expect-error - testing for type of express method on default export
+    expect(typeof useragent.express).toBe('function');
+  });
+
+  it('default export should have UserAgent class', () => {
+    // @ts-expect-error - testing for existence of UserAgent class on default export
+    expect(useragent.UserAgent).toBeDefined();
+  });
+});

--- a/tests/esm-default.test.ts
+++ b/tests/esm-default.test.ts
@@ -3,14 +3,11 @@ import useragent from '../src/index';
 
 describe('ESM Default Export compatibility (issue #177)', () => {
   it('default export should have express() method', () => {
-    // @ts-expect-error - testing for existence of express method on default export
     expect(useragent.express).toBeDefined();
-    // @ts-expect-error - testing for type of express method on default export
     expect(typeof useragent.express).toBe('function');
   });
 
   it('default export should have UserAgent class', () => {
-    // @ts-expect-error - testing for existence of UserAgent class on default export
     expect(useragent.UserAgent).toBeDefined();
   });
 });


### PR DESCRIPTION
This PR restores compatibility with documented ESM usage patterns as reported in issue #177.

### Problem
When using ESM imports, the default export was an instance of `UserAgent` that lacked the `express()` middleware method and the `UserAgent` class definition. This caused failures for users following the documented pattern: 
```js
import useragent from "express-useragent";
app.use(useragent.express());
```

### Solution
Updated `src/index.ts` to attach the `express` middleware function and `UserAgent` class to the default export instance using `Object.assign`. This maintains backward compatibility while enabling the expected ESM usage.

### Validation
- Added `tests/esm-default.test.ts` to reproduce the issue and verify the fix.
- Ran full test suite: **142 tests passed**.
- Verified with `npm run lint` and `npm run typecheck`.
- Verified build output via `npm run build`.

Fixes #177