### PR TITLE
feat: add Arc and Vivaldi browser detection

### DIFF
--- a/src/express-useragent.ts
+++ b/src/express-useragent.ts
@@ -161,6 +161,8 @@ export interface AgentDetails extends Record<string, unknown> {
   source: string;
   isWechat: boolean;
   isWindowsPhone: boolean;
+  isArc: boolean;
+  isVivaldi: boolean;
   electronVersion: string;
   SilkAccelerated?: boolean;
 }
@@ -224,6 +226,8 @@ const DEFAULT_AGENT: AgentDetails = {
   platform: 'unknown',
   isWechat: false,
   isWindowsPhone: false,
+  isArc: false,
+  isVivaldi: false,
   SilkAccelerated: false,
   geoIp: {},
   source: '',
@@ -263,6 +267,8 @@ export class UserAgent {
     Facebook: /FBAV\/([\d\w.]+)/i,
     WebKit: /applewebkit\/([\d\w.]+)/i,
     Wechat: /micromessenger\/([\d\w.]+)/i,
+    Arc: /Arc\/([\d\w.-]+)/i,
+    Vivaldi: /Vivaldi\/([\d\w.-]+)/i,
     Electron: /Electron\/([\d\w.]+)/i,
   };
 
@@ -288,6 +294,8 @@ export class UserAgent {
     AlamoFire: /alamofire/i,
     UC: /UCBrowser/i,
     Facebook: /FBA[NV]/,
+    Arc: /Arc/i,
+    Vivaldi: /Vivaldi/i,
   };
 
   private readonly os: Record<string, RegExp> = {
@@ -615,6 +623,14 @@ export class UserAgent {
     if (this.browsers.AlamoFire.test(string)) {
       agent.isAlamoFire = true;
       return 'AlamoFire';
+    }
+    if (this.browsers.Arc.test(string)) {
+      agent.isArc = true;
+      return 'Arc';
+    }
+    if (this.browsers.Vivaldi.test(string)) {
+      agent.isVivaldi = true;
+      return 'Vivaldi';
     }
     if (this.browsers.Edge.test(string)) {
       agent.isEdge = true;

--- a/tests/arc-vivaldi.test.ts
+++ b/tests/arc-vivaldi.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { UserAgent } from '../src/express-useragent';
+
+describe('Arc and Vivaldi Detection', () => {
+  const ua = new UserAgent();
+
+  it('should detect Arc browser on macOS', () => {
+    const source = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Arc/1.28.2';
+    const s = ua.parse(source);
+    expect(s.isArc).toBe(true);
+    expect(s.browser).toBe('Arc');
+    expect(s.version).toBe('1.28.2');
+    expect(s.isChrome).toBe(false); // Should be identified as Arc specifically
+  });
+
+  it('should detect Vivaldi browser on Windows', () => {
+    const source = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Vivaldi/6.6.3271.48';
+    const s = ua.parse(source);
+    expect(s.isVivaldi).toBe(true);
+    expect(s.browser).toBe('Vivaldi');
+    expect(s.version).toBe('6.6.3271.48');
+    expect(s.isChrome).toBe(false); // Should be identified as Vivaldi specifically
+  });
+});


### PR DESCRIPTION
This PR adds detection for the Arc and Vivaldi browsers.

Arc and Vivaldi are Chromium-based browsers that identify themselves in the User-Agent string. This PR adds the necessary regex patterns and logic to identify them specifically, ensuring they are not just classified as generic Chrome or Chromium.

Changes:
- Added `isArc` and `isVivaldi` to `AgentDetails` interface.
- Added regex patterns to `versions` and `browsers` maps.
- Updated `getBrowser` logic to detect Arc and Vivaldi before falling back to Chrome/Chromium.
- Added tests for both browsers.