### PR TITLE
[codex] Remove registry-url from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Removes `registry-url: https://registry.npmjs.org` from the `actions/setup-node@v6` step in `.github/workflows/publish.yml`.

## Why

`setup-node` writes an `.npmrc` token placeholder when `registry-url` is configured. That causes `npm publish` to prefer token auth and fail with `ENEEDAUTH` instead of using npm OIDC Trusted Publishing.

npm defaults to `registry.npmjs.org`, so the workflow does not need this setting.

## Verification

- Confirmed `.github/workflows/publish.yml` no longer contains `registry-url`
- Did not run npm commands, per OPE-72 constraints