### PR TITLE
Fix SSR browser guard and Yandex versions

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -16,10 +16,16 @@ const api = Object.assign(singleton, { UserAgent, parse, hydrate }) as BrowserAp
 type GlobalHost = typeof globalThis & {
   UserAgent?: typeof UserAgent;
   useragent?: BrowserApi;
+  window?: unknown;
+  document?: unknown;
 };
 
-if (typeof globalThis !== 'undefined') {
-  const host = globalThis as GlobalHost;
+const isBrowserWindow = (host: GlobalHost): boolean =>
+  typeof host.window === 'object' && host.window === host && typeof host.document === 'object';
+
+const host = globalThis as GlobalHost;
+
+if (isBrowserWindow(host)) {
   host.UserAgent = UserAgent;
   host.useragent = api;
 }

--- a/src/express-useragent.ts
+++ b/src/express-useragent.ts
@@ -279,6 +279,7 @@ export class UserAgent {
     Edge: /(?:edge|edga|edgios|edg)\/([\d\w.-]+)/i,
     Firefox: /(?:firefox|fxios)\/([\d\w.-]+)/i,
     IE: /msie\s([\d.]+[\d])|trident\/\d+\.\d+;.*[rv:]+(\d+\.\d)/i,
+    YaBrowser: /(?:yabrowser|yowser)\/([\d\w.-]+)/i,
     Chrome: /(?:chrome|crios)\/([\d\w.-]+)/i,
     Chromium: /chromium\/([\d\w.-]+)/i,
     Safari: /(version|safari)\/([\d\w.-]+)/i,
@@ -935,6 +936,8 @@ export class UserAgent {
         return match(this.versions.Edge) ?? 'unknown';
       case 'PhantomJS':
         return match(this.versions.PhantomJS) ?? 'unknown';
+      case 'YaBrowser':
+        return match(this.versions.YaBrowser) ?? 'unknown';
       case 'Chrome':
         return match(this.versions.Chrome) ?? 'unknown';
       case 'Chromium':

--- a/tests/browser-ssr.test.ts
+++ b/tests/browser-ssr.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type GlobalHost = typeof globalThis & {
+  UserAgent?: unknown;
+  useragent?: unknown;
+  window?: unknown;
+  document?: unknown;
+};
+
+const globalHost = globalThis as GlobalHost;
+
+function resetBrowserGlobals(): void {
+  delete globalHost.UserAgent;
+  delete globalHost.useragent;
+  delete globalHost.window;
+  delete globalHost.document;
+}
+
+afterEach(() => {
+  resetBrowserGlobals();
+});
+
+describe('browser entry SSR guard', () => {
+  it('does not attach globals when imported in a Node SSR environment', async () => {
+    resetBrowserGlobals();
+    vi.resetModules();
+
+    const browserModule = await import('../src/browser.js');
+    const agent = browserModule.parse(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    );
+
+    expect(agent.browser).toBe('Chrome');
+    expect(globalHost.UserAgent).toBeUndefined();
+    expect(globalHost.useragent).toBeUndefined();
+  });
+
+  it('attaches browser globals when imported with a browser-like window host', async () => {
+    resetBrowserGlobals();
+    globalHost.window = globalHost;
+    globalHost.document = {};
+    vi.resetModules();
+
+    await import('../src/browser.js');
+
+    expect(typeof globalHost.UserAgent).toBe('function');
+    expect(globalHost.useragent).toBeDefined();
+    expect(typeof (globalHost.useragent as { parse?: unknown }).parse).toBe('function');
+  });
+});

--- a/tests/p1-bug-fixes.test.ts
+++ b/tests/p1-bug-fixes.test.ts
@@ -140,6 +140,7 @@ describe('Bug #99: Yandex Browser (YaBrowser / Yowser) not detected as Chrome', 
     const agent = useragent.parse(source);
 
     expect(agent.browser).toBe('YaBrowser');
+    expect(agent.version).toBe('13.12.1599.12785');
     expect(agent.isYaBrowser).toBe(true);
     expect(agent.isChrome).toBe(false);
   });
@@ -152,6 +153,7 @@ describe('Bug #99: Yandex Browser (YaBrowser / Yowser) not detected as Chrome', 
     const agent = useragent.parse(source);
 
     expect(agent.browser).toBe('YaBrowser');
+    expect(agent.version).toBe('2.5');
     expect(agent.isYaBrowser).toBe(true);
     expect(agent.isChrome).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Guard the browser bundle global attachment so SSR/Node imports do not write `UserAgent` or `useragent` onto `globalThis` unless the host is a real browser-like `window` with `document`.
- Add regression coverage for SSR imports and browser-like global attachment.
- Parse `YaBrowser` / `Yowser` versions directly instead of falling back to the embedded Chrome version.
- Assert Yandex browser versions in the existing P1 regression tests.

## Validation

- `npm test` -> 12 files, 178 tests passed.
- `npm run typecheck` -> passed.
