### PR TITLE
Fix express-useragent CodeQL alerts

### DIFF
--- a/src/express-useragent.ts
+++ b/src/express-useragent.ts
@@ -271,6 +271,108 @@ function createDefaultAgent(): AgentDetails {
   };
 }
 
+interface ProductToken {
+  name: string;
+  version: string;
+}
+
+const isProductTokenChar = (charCode: number): boolean =>
+  (charCode >= 48 && charCode <= 57) ||
+  (charCode >= 65 && charCode <= 90) ||
+  (charCode >= 97 && charCode <= 122) ||
+  charCode === 45 ||
+  charCode === 46 ||
+  charCode === 95;
+
+const isDigit = (charCode: number): boolean => charCode >= 48 && charCode <= 57;
+
+const readProductToken = (source: string, startIndex = 0): ProductToken | null => {
+  const slashIndex = source.indexOf('/', startIndex);
+  if (slashIndex <= startIndex) {
+    return null;
+  }
+
+  for (let index = startIndex; index < slashIndex; index += 1) {
+    if (!isProductTokenChar(source.charCodeAt(index))) {
+      return null;
+    }
+  }
+
+  let endIndex = slashIndex + 1;
+  while (endIndex < source.length && isProductTokenChar(source.charCodeAt(endIndex))) {
+    endIndex += 1;
+  }
+
+  if (endIndex === slashIndex + 1) {
+    return null;
+  }
+
+  return {
+    name: source.slice(startIndex, slashIndex),
+    version: source.slice(slashIndex + 1, endIndex),
+  };
+};
+
+const readVersionAfterProduct = (source: string, productName: string): string | null => {
+  const token = readProductToken(source);
+  return token?.name.toLowerCase() === productName.toLowerCase() ? token.version : null;
+};
+
+const readIOSDeviceOSMatch = (source: string, device: 'iPad' | 'iPhone'): string | null => {
+  const deviceLower = device.toLowerCase();
+  let searchFrom = 0;
+
+  while (searchFrom < source.length) {
+    const openIndex = source.indexOf('(', searchFrom);
+    if (openIndex === -1) {
+      return null;
+    }
+
+    const closeIndex = source.indexOf(')', openIndex + 1);
+    const segmentEnd = closeIndex === -1 ? source.length : closeIndex;
+    const segment = source.slice(openIndex + 1, segmentEnd);
+    const segmentLower = segment.toLowerCase();
+
+    if (segmentLower.startsWith(deviceLower)) {
+      let osSearchFrom = 0;
+      while (osSearchFrom < segmentLower.length) {
+        const osIndex = segmentLower.indexOf('os ', osSearchFrom);
+        if (osIndex === -1) {
+          break;
+        }
+
+        let versionStart = osIndex + 3;
+        while (segment[versionStart] === ' ') {
+          versionStart += 1;
+        }
+
+        let majorEnd = versionStart;
+        while (majorEnd < segment.length && isDigit(segment.charCodeAt(majorEnd))) {
+          majorEnd += 1;
+        }
+
+        const separator = segment[majorEnd];
+        if (majorEnd > versionStart && (separator === '.' || separator === '_')) {
+          let minorEnd = majorEnd + 1;
+          while (minorEnd < segment.length && isDigit(segment.charCodeAt(minorEnd))) {
+            minorEnd += 1;
+          }
+
+          if (minorEnd > majorEnd + 1) {
+            return `(${segment.slice(0, minorEnd)}`.replace('_', '.');
+          }
+        }
+
+        osSearchFrom = osIndex + 3;
+      }
+    }
+
+    searchFrom = segmentEnd + 1;
+  }
+
+  return null;
+};
+
 /** WebKit DuckDuckGo pattern: " Ddg/X.Y.Z" at end of UA string */
 const DUCKDUCKGO_WEBKIT_REGEXP = /\sDdg\/[\d.]+$/;
 
@@ -278,7 +380,7 @@ export class UserAgent {
   private readonly versions: Record<string, RegExp> = {
     Edge: /(?:edge|edga|edgios|edg)\/([\d\w.-]+)/i,
     Firefox: /(?:firefox|fxios)\/([\d\w.-]+)/i,
-    IE: /msie\s([\d.]+[\d])|trident\/\d+\.\d+;.*[rv:]+(\d+\.\d)/i,
+    IE: /msie\s(\d+(?:\.\d+)?)|trident\/\d+(?:\.\d+)?;[^)]*\brv:(\d+(?:\.\d+)?)/i,
     YaBrowser: /(?:yabrowser|yowser)\/([\d\w.-]+)/i,
     Chrome: /(?:chrome|crios)\/([\d\w.-]+)/i,
     Chromium: /chromium\/([\d\w.-]+)/i,
@@ -369,8 +471,6 @@ export class UserAgent {
     Wii: /wii/i,
     PS3: /playstation 3/i,
     PSP: /playstation portable/i,
-    iPad: /\(iPad.*os (\d+)[._](\d+)/i,
-    iPhone: /\(iPhone.*os (\d+)[._](\d+)/i,
     iOS: /ios/i,
     Bada: /Bada\/(\d+)\.(\d+)/i,
     Curl: /curl\/(\d+)\.(\d+)\.(\d+)/i,
@@ -912,10 +1012,10 @@ export class UserAgent {
     }
 
     if (!string.startsWith('Mozilla')) {
-      const guess = /^([\d\w.-]+)\/[\d\w.-]+/i.exec(string);
+      const guess = readProductToken(string);
       if (guess) {
         agent.isAuthoritative = false;
-        return guess[1];
+        return guess.name;
       }
     }
 
@@ -987,11 +1087,7 @@ export class UserAgent {
         return this.getDuckDuckGoVersion() ?? 'unknown';
       default:
         if (browser !== 'unknown') {
-          const regex = new RegExp(`${browser}[\\/ ]([\\d\\w.\\-]+)`, 'i');
-          const genericMatch = string.match(regex);
-          if (genericMatch) {
-            return genericMatch[1];
-          }
+          return readVersionAfterProduct(string, browser) ?? 'unknown';
         } else {
           this.testWebkit();
           if (this.Agent.isWebkit) {
@@ -1199,15 +1295,15 @@ export class UserAgent {
       this.Agent.isMac = true;
       return 'OS X';
     }
-    const iPadMatch = string.match(this.os.iPad);
+    const iPadMatch = readIOSDeviceOSMatch(string, 'iPad');
     if (iPadMatch) {
       this.Agent.isiPad = true;
-      return iPadMatch[0].replace('_', '.');
+      return iPadMatch;
     }
-    const iPhoneMatch = string.match(this.os.iPhone);
+    const iPhoneMatch = readIOSDeviceOSMatch(string, 'iPhone');
     if (iPhoneMatch) {
       this.Agent.isiPhone = true;
-      return iPhoneMatch[0].replace('_', '.');
+      return iPhoneMatch;
     }
     if (this.os.Bada.test(string)) {
       this.Agent.isBada = true;

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import useragent from '../src/index';
+
+describe('CodeQL ReDoS and regex injection hardening', () => {
+  it('parses generic product tokens without constructing a regex from the product name', () => {
+    const agent = useragent.parse('My.App/1.2.3 OtherProduct/9.9');
+
+    expect(agent.browser).toBe('My.App');
+    expect(agent.version).toBe('1.2.3');
+    expect(agent.isAuthoritative).toBe(false);
+  });
+
+  it('rejects malformed generic product names instead of treating them as regex fragments', () => {
+    const agent = useragent.parse('(a+)+/1.0');
+
+    expect(agent.browser).toBe('unknown');
+    expect(agent.version).toBe('unknown');
+  });
+
+  it('handles long non-product prefixes without regex backtracking', () => {
+    const agent = useragent.parse('-'.repeat(5000));
+
+    expect(agent.browser).toBe('unknown');
+    expect(agent.version).toBe('unknown');
+  });
+
+  it('keeps IE compatibility mode detection after replacing the Trident version regex', () => {
+    const source = 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko';
+
+    const agent = useragent.parse(source);
+
+    expect(agent.browser).toBe('IE');
+    expect(agent.version).toBe('11.0');
+  });
+
+  it('handles repeated iPad-like input without regex backtracking', () => {
+    const agent = useragent.parse(`Mozilla/5.0 (${'iPad'.repeat(2000)}`);
+
+    expect(agent.os).toBe('unknown');
+    expect(agent.isiPad).toBe(true);
+  });
+
+  it('handles repeated iPhone-like input without regex backtracking', () => {
+    const agent = useragent.parse(`Mozilla/5.0 (${'iPhone'.repeat(2000)}`);
+
+    expect(agent.os).toBe('unknown');
+    expect(agent.isiPhone).toBe(true);
+  });
+
+  it('preserves iPad OS detection for normal user agents', () => {
+    const agent = useragent.parse(
+      'Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15',
+    );
+
+    expect(agent.isiPad).toBe(true);
+    expect(agent.os).toBe('OS X');
+  });
+
+  it('preserves iPhone OS detection for native-style user agents', () => {
+    const agent = useragent.parse('MyApp/1.0 (iPhone; iOS 15.0; Scale/3.00)');
+
+    expect(agent.isiPhone).toBe(true);
+    expect(agent.os).toBe('(iPhone; iOS 15.0');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the five high-severity CodeQL alerts reported in OPE-247.

- Replace generic product-token regex parsing with bounded manual token parsing.
- Replace the Trident/IE regex with a bounded pattern.
- Replace iPad/iPhone OS regex matching with bounded parenthetical parsing.
- Remove dynamic regex construction from parsed browser names.
- Add `tests/security.test.ts` regression coverage for the CodeQL patterns and compatibility expectations.

## Validation

- `npm test` (13 files, 186 tests)
- `npm run typecheck`
- `npm run lint`
- `npx prettier --check src/express-useragent.ts tests/security.test.ts`
- `git diff --check`

## CodeQL

Existing alerts 2, 3, 4, 5, and 7 are still open on `refs/heads/master` before merge. This PR removes the exact regex sources referenced by those alerts so the branch CodeQL run can confirm closure.