### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/biggora/express-useragent/",
   "repository": {
     "type": "git",
-    "url": "git://github.com/biggora/express-useragent.git"
+    "url": "git+https://github.com/biggora/express-useragent.git"
   },
   "license": "MIT",
   "publishConfig": {


### PR DESCRIPTION
## Summary
- update the package repository metadata to use the public HTTPS GitHub URL
- keep the change limited to package metadata

## Validation
- node package metadata assertion
- git diff --check
- git ls-remote https://github.com/biggora/express-useragent.git HEAD
- npm pack --dry-run --ignore-scripts --json passed
